### PR TITLE
Split out z parts, added a nut holder to use with threaded rods instead of leadscrews

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Please note this list doesn't include anything for an extruder.  The design incl
 * 2x 8mm rod, 345mm length (X axis)
 * 16x LM8UU Bearing
 * 2x MakersToolWorks Leadscrews ( http://store.makerstoolworks.com/motion/z-axis-lead-screw-and-nut-single/ )
+*    Optional: 2x M8x1.25 threaded rod, 400mm length + 2x M8x1.25 nuts.
 * 1x Set of two MakersToolWorks shaft couplers (optional, can use vinyl tubing) ( http://store.makerstoolworks.com/motion/helical-shaft-couplers-set-of-2/ )
 * LOTS T-slot Nuts, M5 Threads
 * LOTS M5x10 Bolts

--- a/lm8uu_z_holder.scad
+++ b/lm8uu_z_holder.scad
@@ -1,0 +1,53 @@
+// Various parts for Z Assembly.
+// Print 4 of lm8uu_retainer(), 4 of z_rod_holder(), 2 of z_motor_mount, 2 of z_end()
+// TODO: Should be broken out to separate files eventually.
+// (c) 2014, Christopher "ScribbleJ" Jansen
+include <common.scad>
+use <platform.scad>
+
+
+
+
+
+//lm8uu_retainer();
+//translate([40,0,0]) 
+    liftNut_retainer();
+
+module lm8uu_retainer()
+{
+  difference()
+  {
+    union()
+    {
+      cylinder(r=lm8uu_r + corner_thick,h=bed_box_h);
+      for(a=[0:120:240])
+        rotate([0,0,a]) translate([0,lm8uu_r+corner_thick+lm8uu_bolt_r]) cylinder(r=lm8uu_nut_r,h=bed_box_h);
+    }
+    translate([0,0,-1])
+    {
+      polyhole(r=lm8uu_r,h=huge,v=16);
+      for(a=[0:120:240])
+        rotate([0,0,a]) translate([0,lm8uu_r+corner_thick+lm8uu_bolt_r]) polyhole(r=lm8uu_bolt_r,h=huge);
+    }
+  }
+}
+
+module liftNut_retainer()
+{
+  difference()
+  {
+    union()
+    {
+      cylinder(r=lm8uu_r + corner_thick,h=liftNutRetainer_h);
+      for(a=[0:120:240])
+        rotate([0,0,a]) translate([0,lm8uu_r+corner_thick+lm8uu_bolt_r]) cylinder(r=lm8uu_nut_r,h=liftNutRetainer_h);
+    }
+    translate([0,0,-1])
+    {
+      polyhole(r=liftNut_od/2*1.05,h=liftNut_h*0.6,v=6);
+      polyhole(r=liftNut_d/2 * 1.4 ,h=huge,v=16);
+      for(a=[0:120:240])
+        rotate([0,0,a]) translate([0,lm8uu_r+corner_thick+lm8uu_bolt_r]) polyhole(r=lm8uu_bolt_r,h=huge);
+    }
+  }
+}

--- a/lm8uu_z_holder.scad
+++ b/lm8uu_z_holder.scad
@@ -1,17 +1,11 @@
-// Various parts for Z Assembly.
-// Print 4 of lm8uu_retainer(), 4 of z_rod_holder(), 2 of z_motor_mount, 2 of z_end()
-// TODO: Should be broken out to separate files eventually.
+// LM8uu Holder for z axis.
+// Print 4 of lm8uu_retainer()
 // (c) 2014, Christopher "ScribbleJ" Jansen
 include <common.scad>
 use <platform.scad>
 
+lm8uu_retainer();
 
-
-
-
-//lm8uu_retainer();
-//translate([40,0,0]) 
-    liftNut_retainer();
 
 module lm8uu_retainer()
 {

--- a/vars.scad
+++ b/vars.scad
@@ -11,8 +11,9 @@ printer_h = 400;
 huge=500;
 
 // 608 Bearings
-bearing_w = 7;
-bearing_d = 22;
+//Added some extra space to the bearing retainer so I don't break them during assembly
+bearing_w = 7*1.01;  
+bearing_d = 22*1.01;
 bearing_r = bearing_d/2;
 bearing_hole_d = 8;
 bearing_hole_r = bearing_hole_d/2;
@@ -25,8 +26,15 @@ misc_bolt_pitch = 0.5;
 misc_bolthead_d = misc_bolt_d*2;
 misc_bolthead_r = misc_bolthead_d/2;
 
+//Retainer for using a regular bolt (M8) instead of a proper leadscrew as the Z lift nut.
+liftNut_d = 8;
+liftNut_od = liftNut_d *2;
+liftNut_h = liftNut_d * 0.8;
+liftNutRetainer_h = liftNut_h ;
+
 // Bearing retainers
-retainer_shell_thick = 0.5;
+//Added some extra thickness to the bearing retainer so I don't break them during assembly
+retainer_shell_thick = 0.6;
 retainer_shell_sep   = 0.25;
 retainer_lip_thick   = 2;
 retainer_inner_width = 1;

--- a/z_end.scad
+++ b/z_end.scad
@@ -1,0 +1,64 @@
+// Z end rod holder
+// Print 2
+// (c) 2014, Christopher "ScribbleJ" Jansen
+include <common.scad>
+use <platform.scad>
+
+z_end();
+
+module z_end(motor=false)
+{
+  rod_holder_r = motor_w/2 + bushing_material_thick + corner_thick + rod_r;
+  difference()
+  {
+    union()
+    {
+      cube([z_rod_sep,tslot_w,corner_thick]);
+      translate([0,-corner_thick,0])
+      {
+        scale([0.5,1,1]) rotate([-90,0,0]) cylinder(r=rod_holder_r, h=tslot_w+corner_thick*2);
+        translate([z_rod_sep,0,0]) scale([0.5,1,1]) rotate([-90,0,0]) cylinder(r=rod_holder_r, h=tslot_w+corner_thick*2);
+      }
+    }
+    translate([-huge/2,-huge/2,-huge]) cube([huge,huge,huge]);
+
+    // Rod holders
+    translate([0,0,corner_thick + motor_w/2])
+    {
+      rotate([-90,0,0])
+      {
+        polyhole(r=rod_r,h=huge,v=8,a=360/16);
+        translate([z_rod_sep,0,0]) polyhole(r=rod_r,h=huge,v=8,a=360/16);
+      }
+    }
+
+    // Tslot bolts
+    for(x=[rod_holder_r/2 - tslot_bolthead_r,z_rod_sep - rod_holder_r/2 + tslot_bolthead_r,
+           -rod_holder_r/2 + tslot_bolthead_r,z_rod_sep + rod_holder_r/2 - tslot_bolthead_r
+          ])
+    {
+      translate([x,tslot_w/2,corner_thick]) bolt(tslot_bolt_r,tslot_bolthead_r);
+    }
+  }
+
+  if(motor)
+  {
+    difference()
+    {
+      translate([z_rod_sep/2 - motor_w/2 - corner_thick, -motor_h-motor_bracket_thick+tslot_w+corner_thick,0]) cube([motor_w + corner_thick*2, motor_h + motor_bracket_thick, motor_w + corner_thick]);
+
+      translate([z_rod_sep/2 - motor_w/2, -motor_h + tslot_w + corner_thick, corner_thick]) cube([motor_w, motor_h+1, motor_w+1]);
+      translate([0,tslot_w+corner_thick,corner_thick]) rotate([45,0,0]) cube([huge,huge,huge]);
+      translate([z_rod_sep/2,0,corner_thick + motor_w/2])
+      {
+        rotate([90,0,0]) polyhole(r=motor_flange_r,h=huge);
+        for(x=[-motor_bolt_sep/2,motor_bolt_sep/2])
+        for(z=[-motor_bolt_sep/2,motor_bolt_sep/2])
+        {
+          translate([x,0,z]) rotate([90,0,0]) polyhole(r=misc_bolt_r,h=huge);
+        }
+      }
+    }
+
+  }
+}

--- a/z_motor_mount.scad
+++ b/z_motor_mount.scad
@@ -1,0 +1,55 @@
+// Z motor mount
+// Print 2
+// (c) 2014, Christopher "ScribbleJ" Jansen
+include <common.scad>
+use <platform.scad>
+
+
+z_motor_mount();
+
+module z_motor_mount()
+{
+
+  difference()
+  {
+    union()
+    {
+      // Basic Bracket
+      cube([motor_w + corner_thick*2, motor_w+corner_thick, motor_h+motor_bracket_thick]);
+      // ORB
+      translate([motor_w/2+corner_thick,motor_w+corner_thick,motor_h+motor_bracket_thick-tslot_w/2-corner_thick]) scale([motor_w+corner_thick*2+tslot_bolthead_r*4+4,(tslot_w+corner_thick)*2,(motor_h+motor_bracket_thick)*2]) sphere(r=.5,$fn=32);
+    }
+
+    // Motor Cutout
+    translate([corner_thick,-1,motor_bracket_thick]) cube([motor_w,motor_w+1,motor_h+1]);
+    // Angle
+    translate([-huge/2,0,motor_bracket_thick]) rotate([45,0,0]) cube([huge,huge,huge]);
+
+    // T-slot bolt holes
+    // front
+    translate([-tslot_bolthead_r-2,motor_w,motor_h+motor_bracket_thick-corner_thick-tslot_w/2])rotate([90,0,0]) bolt(bolt_r=tslot_bolt_r,bolthead_r=tslot_bolthead_r,v=8,a=360/16); 
+    translate([motor_w+corner_thick*2+tslot_bolthead_r+2,motor_w,motor_h+motor_bracket_thick-corner_thick-tslot_w/2])rotate([90,0,0]) bolt(bolt_r=tslot_bolt_r,bolthead_r=tslot_bolthead_r,v=8,a=360/16); 
+    // back
+    translate([motor_w/2+corner_thick,motor_w+corner_thick*2+tslot_w,motor_h+motor_bracket_thick-corner_thick-tslot_w/2]) rotate([-90,0,0]) bolt(bolt_r=tslot_bolt_r,bolthead_r=tslot_bolthead_r,bolt_len=10); 
+    // top
+    translate([motor_w/2+corner_thick-motor_bolt_sep/2,motor_w+corner_thick+tslot_w/2,motor_h+motor_bracket_thick-corner_thick*2-tslot_w]) rotate([180,0,0]) bolt(bolt_r=tslot_bolt_r,bolthead_r=tslot_bolthead_r,v=4,a=360/8);
+    translate([motor_w/2+corner_thick+motor_bolt_sep/2,motor_w+corner_thick+tslot_w/2,motor_h+motor_bracket_thick-corner_thick*2-tslot_w]) rotate([180,0,0]) bolt(bolt_r=tslot_bolt_r,bolthead_r=tslot_bolthead_r,v=4,a=360/8);
+
+    // motor shaft and bolt holes
+    translate([corner_thick + motor_w/2,motor_w/2,-1])
+    {
+      polyhole(r=motor_flange_r,h=huge);
+      for(x=[-motor_bolt_sep/2,motor_bolt_sep/2])
+      for(y=[-motor_bolt_sep/2,motor_bolt_sep/2])
+      {
+        translate([x,y,0]) polyhole(r=misc_bolt_r,h=huge);
+      }
+    }
+
+    // ORB cuts
+    translate([-huge/2,-huge/2,-huge]) cube([huge,huge,huge]);
+    translate([-huge/2,-huge/2,motor_bracket_thick+motor_h-corner_thick]) cube([huge,huge,huge]);
+
+    translate([-huge/2,motor_w+corner_thick,motor_h+motor_bracket_thick-tslot_w-corner_thick]) cube([huge,tslot_w,tslot_w]);
+  }
+}

--- a/z_parts.scad
+++ b/z_parts.scad
@@ -1,9 +1,9 @@
-// Various parts for Z Assembly.
-// Print 4 of lm8uu_retainer(), 4 of z_rod_holder(), 2 of z_motor_mount, 2 of z_end()
-// TODO: Should be broken out to separate files eventually.
+// Assembly of Z axis.
+//See used files files for printing instructions.
 // (c) 2014, Christopher "ScribbleJ" Jansen
 include <common.scad>
 use <lm8uu_z_holder.scad>
+use <liftnut_z_holder.scad>
 use <z_rod_holder.scad>
 use <z_motor_mount.scad>
 use <z_end.scad>

--- a/z_parts.scad
+++ b/z_parts.scad
@@ -3,6 +3,10 @@
 // TODO: Should be broken out to separate files eventually.
 // (c) 2014, Christopher "ScribbleJ" Jansen
 include <common.scad>
+use <lm8uu_z_holder.scad>
+use <z_rod_holder.scad>
+use <z_motor_mount.scad>
+use <z_end.scad>
 use <platform.scad>
 
 display_z_assembly();
@@ -20,24 +24,6 @@ module display_z_bottom()
 }
 
 
-module lm8uu_retainer()
-{
-  difference()
-  {
-    union()
-    {
-      cylinder(r=lm8uu_r + corner_thick,h=bed_box_h);
-      for(a=[0:120:240])
-        rotate([0,0,a]) translate([0,lm8uu_r+corner_thick+lm8uu_bolt_r]) cylinder(r=lm8uu_nut_r,h=bed_box_h);
-    }
-    translate([0,0,-1])
-    {
-      polyhole(r=lm8uu_r,h=huge,v=16);
-      for(a=[0:120:240])
-        rotate([0,0,a]) translate([0,lm8uu_r+corner_thick+lm8uu_bolt_r]) polyhole(r=lm8uu_bolt_r,h=huge);
-    }
-  }
-}
 
 module display_z_assembly()
 {
@@ -62,133 +48,6 @@ module display_z_assembly()
 }
   
 
-module z_rod_holder()
-{
-  rod_holder_r = motor_w/2 + bushing_material_thick + corner_thick + rod_r;
-
-  difference()
-  {
-    translate([0,-corner_thick,0]) scale([0.5,1,1]) rotate([-90,0,0]) cylinder(r=rod_holder_r, h=tslot_w+corner_thick*2);
-
-    // Garbage
-    translate([-huge/2,-huge/2,-huge]) cube([huge,huge,huge]);
-
-    // Rod Hole
-    translate([0,tslot_w,corner_thick + motor_w/2])
-      rotate([90,0,0])
-        polyhole(r=rod_r,h=huge,v=8,a=360/16);
-
-    // Tslot bolts
-    for(x=[rod_holder_r/2 - tslot_bolthead_r,-rod_holder_r/2 + tslot_bolthead_r])
-    {
-      translate([x,tslot_w/2,corner_thick]) bolt(tslot_bolt_r,tslot_bolthead_r);
-    }
-
-  }
-
-}
 
 
-module z_motor_mount()
-{
 
-  difference()
-  {
-    union()
-    {
-      // Basic Bracket
-      cube([motor_w + corner_thick*2, motor_w+corner_thick, motor_h+motor_bracket_thick]);
-      // ORB
-      translate([motor_w/2+corner_thick,motor_w+corner_thick,motor_h+motor_bracket_thick-tslot_w/2-corner_thick]) scale([motor_w+corner_thick*2+tslot_bolthead_r*4+4,(tslot_w+corner_thick)*2,(motor_h+motor_bracket_thick)*2]) sphere(r=.5,$fn=32);
-    }
-
-    // Motor Cutout
-    translate([corner_thick,-1,motor_bracket_thick]) cube([motor_w,motor_w+1,motor_h+1]);
-    // Angle
-    translate([-huge/2,0,motor_bracket_thick]) rotate([45,0,0]) cube([huge,huge,huge]);
-
-    // T-slot bolt holes
-    // front
-    translate([-tslot_bolthead_r-2,motor_w,motor_h+motor_bracket_thick-corner_thick-tslot_w/2])rotate([90,0,0]) bolt(bolt_r=tslot_bolt_r,bolthead_r=tslot_bolthead_r,v=8,a=360/16); 
-    translate([motor_w+corner_thick*2+tslot_bolthead_r+2,motor_w,motor_h+motor_bracket_thick-corner_thick-tslot_w/2])rotate([90,0,0]) bolt(bolt_r=tslot_bolt_r,bolthead_r=tslot_bolthead_r,v=8,a=360/16); 
-    // back
-    translate([motor_w/2+corner_thick,motor_w+corner_thick*2+tslot_w,motor_h+motor_bracket_thick-corner_thick-tslot_w/2]) rotate([-90,0,0]) bolt(bolt_r=tslot_bolt_r,bolthead_r=tslot_bolthead_r,bolt_len=10); 
-    // top
-    translate([motor_w/2+corner_thick-motor_bolt_sep/2,motor_w+corner_thick+tslot_w/2,motor_h+motor_bracket_thick-corner_thick*2-tslot_w]) rotate([180,0,0]) bolt(bolt_r=tslot_bolt_r,bolthead_r=tslot_bolthead_r,v=4,a=360/8);
-    translate([motor_w/2+corner_thick+motor_bolt_sep/2,motor_w+corner_thick+tslot_w/2,motor_h+motor_bracket_thick-corner_thick*2-tslot_w]) rotate([180,0,0]) bolt(bolt_r=tslot_bolt_r,bolthead_r=tslot_bolthead_r,v=4,a=360/8);
-
-    // motor shaft and bolt holes
-    translate([corner_thick + motor_w/2,motor_w/2,-1])
-    {
-      polyhole(r=motor_flange_r,h=huge);
-      for(x=[-motor_bolt_sep/2,motor_bolt_sep/2])
-      for(y=[-motor_bolt_sep/2,motor_bolt_sep/2])
-      {
-        translate([x,y,0]) polyhole(r=misc_bolt_r,h=huge);
-      }
-    }
-
-    // ORB cuts
-    translate([-huge/2,-huge/2,-huge]) cube([huge,huge,huge]);
-    translate([-huge/2,-huge/2,motor_bracket_thick+motor_h-corner_thick]) cube([huge,huge,huge]);
-
-    translate([-huge/2,motor_w+corner_thick,motor_h+motor_bracket_thick-tslot_w-corner_thick]) cube([huge,tslot_w,tslot_w]);
-  }
-}
-
-module z_end(motor=false)
-{
-  rod_holder_r = motor_w/2 + bushing_material_thick + corner_thick + rod_r;
-  difference()
-  {
-    union()
-    {
-      cube([z_rod_sep,tslot_w,corner_thick]);
-      translate([0,-corner_thick,0])
-      {
-        scale([0.5,1,1]) rotate([-90,0,0]) cylinder(r=rod_holder_r, h=tslot_w+corner_thick*2);
-        translate([z_rod_sep,0,0]) scale([0.5,1,1]) rotate([-90,0,0]) cylinder(r=rod_holder_r, h=tslot_w+corner_thick*2);
-      }
-    }
-    translate([-huge/2,-huge/2,-huge]) cube([huge,huge,huge]);
-
-    // Rod holders
-    translate([0,0,corner_thick + motor_w/2])
-    {
-      rotate([-90,0,0])
-      {
-        polyhole(r=rod_r,h=huge,v=8,a=360/16);
-        translate([z_rod_sep,0,0]) polyhole(r=rod_r,h=huge,v=8,a=360/16);
-      }
-    }
-
-    // Tslot bolts
-    for(x=[rod_holder_r/2 - tslot_bolthead_r,z_rod_sep - rod_holder_r/2 + tslot_bolthead_r,
-           -rod_holder_r/2 + tslot_bolthead_r,z_rod_sep + rod_holder_r/2 - tslot_bolthead_r
-          ])
-    {
-      translate([x,tslot_w/2,corner_thick]) bolt(tslot_bolt_r,tslot_bolthead_r);
-    }
-  }
-
-  if(motor)
-  {
-    difference()
-    {
-      translate([z_rod_sep/2 - motor_w/2 - corner_thick, -motor_h-motor_bracket_thick+tslot_w+corner_thick,0]) cube([motor_w + corner_thick*2, motor_h + motor_bracket_thick, motor_w + corner_thick]);
-
-      translate([z_rod_sep/2 - motor_w/2, -motor_h + tslot_w + corner_thick, corner_thick]) cube([motor_w, motor_h+1, motor_w+1]);
-      translate([0,tslot_w+corner_thick,corner_thick]) rotate([45,0,0]) cube([huge,huge,huge]);
-      translate([z_rod_sep/2,0,corner_thick + motor_w/2])
-      {
-        rotate([90,0,0]) polyhole(r=motor_flange_r,h=huge);
-        for(x=[-motor_bolt_sep/2,motor_bolt_sep/2])
-        for(z=[-motor_bolt_sep/2,motor_bolt_sep/2])
-        {
-          translate([x,0,z]) rotate([90,0,0]) polyhole(r=misc_bolt_r,h=huge);
-        }
-      }
-    }
-
-  }
-}

--- a/z_rod_holder.scad
+++ b/z_rod_holder.scad
@@ -1,0 +1,33 @@
+// Z rod holder
+// Print 4
+// (c) 2014, Christopher "ScribbleJ" Jansen
+include <common.scad>
+use <platform.scad>
+
+z_rod_holder();
+
+module z_rod_holder()
+{
+  rod_holder_r = motor_w/2 + bushing_material_thick + corner_thick + rod_r;
+
+  difference()
+  {
+    translate([0,-corner_thick,0]) scale([0.5,1,1]) rotate([-90,0,0]) cylinder(r=rod_holder_r, h=tslot_w+corner_thick*2);
+
+    // Garbage
+    translate([-huge/2,-huge/2,-huge]) cube([huge,huge,huge]);
+
+    // Rod Hole
+    translate([0,tslot_w,corner_thick + motor_w/2])
+      rotate([90,0,0])
+        polyhole(r=rod_r,h=huge,v=8,a=360/16);
+
+    // Tslot bolts
+    for(x=[rod_holder_r/2 - tslot_bolthead_r,-rod_holder_r/2 + tslot_bolthead_r])
+    {
+      translate([x,tslot_w/2,corner_thick]) bolt(tslot_bolt_r,tslot_bolthead_r);
+    }
+
+  }
+
+}


### PR DESCRIPTION
Based on the lm8uu_retainer module, I have created and added in a part to create a hex-nut holder to be used on the z axis instead of a proper leadscrew/leadnut module.

Print 4 (2 for each side).  They are designed so that they make a sandwich around the nut and match the bolt pattern for the frame.

I also split out the z_parts per the author's todo.  

I tweaked some of the bearing size parameters in vars.scad because I seem to need a lot of sanding on the 608 bearing retainers in order to actually fit them together.  I also made them a little thicker because I keep breaking them.  Those changes should probably be backed out - they are really an artifact of my current printers calibration and tolerances.
